### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ go install github.com/maaslalani/gambit@latest
 or run from source
 
 ```sh
-git clone github.com/maaslalani/gambit
+git clone https://github.com/maaslalani/gambit
 go run ./...
 ```
 


### PR DESCRIPTION
When copying and pasting into the terminal from the README, it doesn't work.
```sh
git clone github.com/maaslalani/gambit
```

The new fix is by adding `https://` and that works.